### PR TITLE
Update bootloader handle references

### DIFF
--- a/Core/Inc/SideQuestBootloader.h
+++ b/Core/Inc/SideQuestBootloader.h
@@ -45,14 +45,14 @@ typedef enum {
 } BootState;
 
 typedef struct {
-    UART_HandleTypeDef  Boot_UART_Handle;
-    I2C_HandleTypeDef   Boot_I2C_Handle;
+    UART_HandleTypeDef *  Boot_UART_Handle;
+    I2C_HandleTypeDef *   Boot_I2C_Handle;
 } tBootloader;
 
 typedef void (*pFunction)(void);
 
 
-void Bootloader_init(I2C_HandleTypeDef i2c_handle, UART_HandleTypeDef UART_Handle);
+void Bootloader_init(I2C_HandleTypeDef *i2c_handle, UART_HandleTypeDef *UART_Handle);
 void SideQuestBootloader(void);
 bool generate_random_bytes(uint8_t *buffer, uint32_t length);
 void jump_to_app(uint32_t address_start);

--- a/Core/Src/SideQuestBootloader.c
+++ b/Core/Src/SideQuestBootloader.c
@@ -33,11 +33,11 @@ void SideQuestBootloader(void){
     case STATE_INIT: {
         if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)){
             uint8_t crash_Flag = CRASHED;
-            EEPROM_Write_Flag(&crash_Flag, PAGE_CRASH_FLAG, &SideQuest->Boot_I2C_Handle);
+            EEPROM_Write_Flag(&crash_Flag, PAGE_CRASH_FLAG, SideQuest->Boot_I2C_Handle);
         } else {break;}
 
         uint8_t LP_flag;
-        if (EEPROM_Read_Flag(&LP_flag, PAGE_LP_FLAG, &SideQuest->Boot_I2C_Handle)){
+        if (EEPROM_Read_Flag(&LP_flag, PAGE_LP_FLAG, SideQuest->Boot_I2C_Handle)){
             if (LP_flag == LOW_POWER){
                 printf("Low Power. Jumping to app");
                 jump_to_app(FLASH2_START);
@@ -45,21 +45,21 @@ void SideQuestBootloader(void){
         } else {break;}
 
         uint8_t id_flag_data;
-        if (EEPROM_ReadByte(PAGE_ID, &id_flag_data, &SideQuest->Boot_I2C_Handle)){
+        if (EEPROM_ReadByte(PAGE_ID, &id_flag_data, SideQuest->Boot_I2C_Handle)){
             if (id_flag_data == 0){
                 uint8_t random_bytes[30];
                 if (generate_random_bytes(random_bytes, sizeof(random_bytes))){
                     uint16_t start_address = PAGE_ID;
                     uint8_t new_flag = 1;
-                    EEPROM_WriteByte(start_address, new_flag, &SideQuest->Boot_I2C_Handle);
+                    EEPROM_WriteByte(start_address, new_flag, SideQuest->Boot_I2C_Handle);
                     start_address += 1;
-                    EEPROM_WritePage(start_address, random_bytes, 30, &SideQuest->Boot_I2C_Handle);
+                    EEPROM_WritePage(start_address, random_bytes, 30, SideQuest->Boot_I2C_Handle);
                 } else {break;}
             }
         } else {break;}
 
         uint8_t crashed_flag;
-        if (EEPROM_Read_Flag(&crashed_flag, PAGE_CRASH_FLAG, &SideQuest->Boot_I2C_Handle)){
+        if (EEPROM_Read_Flag(&crashed_flag, PAGE_CRASH_FLAG, SideQuest->Boot_I2C_Handle)){
             if (crashed_flag == CRASHED){
                 SideQuest_State = STATE_STARTING_READ_FROM_STABLE;
             } else {
@@ -72,7 +72,7 @@ void SideQuestBootloader(void){
 
     case STATE_VERIFY_UPDATE: {
         uint8_t update_ready_flag;
-        if (EEPROM_Read_Flag(&update_ready_flag, PAGE_UPDATE_FLAG, &SideQuest->Boot_I2C_Handle)){
+        if (EEPROM_Read_Flag(&update_ready_flag, PAGE_UPDATE_FLAG, SideQuest->Boot_I2C_Handle)){
             if (update_ready_flag == UPDATE_NEEDED) {
                 SideQuest_State = STATE_CHECK_FW;
             } else {
@@ -85,12 +85,12 @@ void SideQuestBootloader(void){
 
     case STATE_CHECK_FW:{
         uint8_t update_flag;
-        if (EEPROM_Read_Flag(&update_flag, PAGE_UPDATE_FLAG, &SideQuest->Boot_I2C_Handle)){
+        if (EEPROM_Read_Flag(&update_flag, PAGE_UPDATE_FLAG, SideQuest->Boot_I2C_Handle)){
             if (update_flag == UPDATE_NEEDED){
                 uint8_t fw_header[30];
                 memcpy(fw_header, UPDATE_IMAGE_START, 30);
                 uint8_t id_header[30];
-                if (EEPROM_Read(PAGE_ID + 1, id_header, 30, &SideQuest->Boot_I2C_Handle)){
+                if (EEPROM_Read(PAGE_ID + 1, id_header, 30, SideQuest->Boot_I2C_Handle)){
                     if (memcmp(fw_header, id_header, sizeof(fw_header)) == 0){
                         firmware_address = UPDATE_IMAGE_START;
                         SideQuest_State = STATE_ERASE_FLASH;
@@ -171,7 +171,7 @@ void SideQuestBootloader(void){
         uint32_t crc2 = HAL_CRC_Calculate(&hcrc, pSuccess_write_marker, (BLOCKSIZE / 8) / (sizeof(uint32_t)));
         if (crc1 == crc2) {
             uint8_t good_to_go = GOOD_TO_GO;
-            EEPROM_Write_Flag(&good_to_go, PAGE_UPDATE_FLAG, &SideQuest->Boot_I2C_Handle);
+            EEPROM_Write_Flag(&good_to_go, PAGE_UPDATE_FLAG, SideQuest->Boot_I2C_Handle);
         } else {
             SideQuest_State = STATE_ERROR;
         }
@@ -223,18 +223,18 @@ bool generate_random_bytes(uint8_t *buffer, uint32_t length) { //length should b
     return true;
 }
 
-void Bootloader_init(I2C_HandleTypeDef i2c_handle, UART_HandleTypeDef UART_Handle){
+void Bootloader_init(I2C_HandleTypeDef *i2c_handle, UART_HandleTypeDef *UART_Handle){
     SideQuest = (tBootloader *)malloc(sizeof(tBootloader));
     SideQuest->Boot_I2C_Handle = i2c_handle;
     SideQuest->Boot_UART_Handle = UART_Handle;
-    UART_SetHandle(&SideQuest->Boot_UART_Handle);
+    UART_SetHandle(SideQuest->Boot_UART_Handle);
     SideQuest_State = STATE_INIT;
 }
 
 void jump_to_app(uint32_t address_start){
     if (Valid_FW_Check()){
-        HAL_I2C_DeInit(&SideQuest->Boot_I2C_Handle);
-        HAL_UART_DeInit(&SideQuest->Boot_UART_Handle);
+        HAL_I2C_DeInit(SideQuest->Boot_I2C_Handle);
+        HAL_UART_DeInit(SideQuest->Boot_UART_Handle);
         HAL_CRC_DeInit(&hcrc);
         HAL_RCC_DeInit();
         HAL_DeInit();

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -107,7 +107,7 @@ int main(void)
   MX_I2C1_Init();
   /* USER CODE BEGIN 2 */
 
-  Bootloader_init(hi2c1, huart2);
+  Bootloader_init(&hi2c1, &huart2);
 
   /* USER CODE END 2 */
 


### PR DESCRIPTION
## Summary
- store bootloader HAL handles as pointers
- pass handles directly instead of their addresses

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e99e405083328055f641108b6ddc